### PR TITLE
웹뷰 구글 로그인 구현

### DIFF
--- a/window.d.ts
+++ b/window.d.ts
@@ -1,0 +1,5 @@
+interface Window {
+  ReactNativeWebView?: {
+    postMessage: (message: string) => void;
+  };
+}


### PR DESCRIPTION
## ReactNativeWebView 객체
rn에서 웹뷰 컴포넌트로 웹을 띄우면, window 객체에 ReactNativeWebView 라는 객체를 넣어줘요.
그래서 ReactNativeWebView 존재 유무로 웹인지 웹뷰인지 구분하고 메세지를 전송할 때도 해당 객체의 메서드를 사용합니다.

## 메세지 보낼 때
- ReactNativeWebView.postMessage(message: string)에 전달할 내용을 직렬화 해서 보내요.

## 받을 때
- addEventListener에서 이벤트 명을 'message'로 수신하고, 콜백의 event 객체 내부의 data 객체에 rn에서 전달한 데이터가 들어있어요.

## 작업 내용
- window 객체에 ReactNativeWebView 타입 확장 835791768ded17de9ed3c53591136f2868ce5ee6
- 구글 로그인 구현
  - postMesaage로 구글 로그인 요청 (web) -> 구글 로그인 함수 실행 (app) -> 구글 로그인 성공 시 토큰을 전송 (app) -> message 이벤트로 수신하고 콜백에서 후처리 (web)