### PR TITLE
카드 페이지 safe area inset 추가

### DIFF
--- a/src/app/card/page.tsx
+++ b/src/app/card/page.tsx
@@ -6,6 +6,8 @@ import { useRouter } from "next/navigation";
 import DotSpinner from "@/components/shared/Spinner/DotSpinner";
 import dynamic from "next/dynamic";
 import FramePageSkeleton from "@/components/shared/Skeleton/FramePageSkeleton";
+import clsx from "clsx";
+import { useReactNativeWebView } from "@/components/shared/providers/ReactNativeWebViewProvider";
 
 const ChooseFrame = dynamic(() => import("@/components/cards/ChooseFrame"), {
   ssr: false,
@@ -23,6 +25,7 @@ export default function Page() {
   const handleGatheringChange = () => {
     setStep(step + 1);
   };
+  const { isReactNativeWebView } = useReactNativeWebView();
 
   const getHeaderName = () => {
     if (step === 1) {
@@ -33,8 +36,13 @@ export default function Page() {
   };
 
   return (
-    <div className="bg-base-white h-dvh overflow-y-scroll no-scrollbar">
-      <header className={styles.header}>
+    <div className={"bg-base-white h-dvh overflow-y-scroll no-scrollbar"}>
+      <header
+        className={clsx(
+          styles.header,
+          isReactNativeWebView ? "pt-safe-top" : ""
+        )}
+      >
         <div
           className="py-[10px] pl-[17px] pr-[3px] cursor-pointer"
           onClick={() => {

--- a/src/app/invitation/page.tsx
+++ b/src/app/invitation/page.tsx
@@ -17,6 +17,7 @@ import { useInfiniteScrollByRef } from "@/hooks/useInfiniteScroll";
 import useReadNotification from "@/components/notice/hooks/useReadNotification";
 import { useQueryClient } from "@tanstack/react-query";
 import NoInvitation from "@/components/invitation/NoInvitation";
+import { useReactNativeWebView } from "@/components/shared/providers/ReactNativeWebViewProvider";
 
 export default function InvitationPage() {
   const queryClient = useQueryClient();
@@ -25,6 +26,7 @@ export default function InvitationPage() {
   const [isModalOpen, setModalOpen] = useState<boolean>(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const containerRef_r = useRef<HTMLDivElement>(null);
+  const { isReactNativeWebView } = useReactNativeWebView();
 
   const { selectedTab, swiperRef, handleSlideChange, handleTabClick } =
     useTabs();
@@ -143,7 +145,7 @@ export default function InvitationPage() {
   }, []);
 
   return (
-    <div className="h-dvh">
+    <div className={clsx("h-dvh", isReactNativeWebView ? "pt-safe-top" : "")}>
       <div
         id="filter"
         className={clsx(filterStyle, isPast ? "shadow-bottom" : "")}

--- a/src/app/notice/page.tsx
+++ b/src/app/notice/page.tsx
@@ -6,6 +6,8 @@ import useReadNotification from "@/components/notice/hooks/useReadNotification";
 import Flex from "@/components/shared/Flex";
 import ArrowLeftIcon from "@/components/shared/Icon/ArrowLeftIcon";
 import NoticeContainer from "@/components/notice/NoticeContainer";
+import clsx from "clsx";
+import { useReactNativeWebView } from "@/components/shared/providers/ReactNativeWebViewProvider";
 
 export default function NoticePage() {
   const router = useRouter();
@@ -15,6 +17,7 @@ export default function NoticePage() {
       await queryClient.invalidateQueries({ queryKey: ["notification"] });
     },
   });
+  const { isReactNativeWebView } = useReactNativeWebView();
 
   useEffect(() => {
     read();
@@ -24,7 +27,10 @@ export default function NoticePage() {
     <Flex direction="column" className="h-dvh bg-grayscale-50">
       <Flex
         align="center"
-        className="max-w-[430px] mx-auto w-full fixed h-12 gap-[6px] bg-grayscale-50"
+        className={clsx(
+          "max-w-[430px] mx-auto w-full fixed h-12 gap-[6px] bg-grayscale-50",
+          isReactNativeWebView ? "pt-safe-top" : ""
+        )}
       >
         <div
           className={arrowIconContainerStyle}

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -24,6 +24,10 @@ import { useRouter } from "next/navigation";
 import useMaze from "@/hooks/useMaze";
 import useScrollToTop from "@/hooks/useScrollToTop";
 import dynamic from "next/dynamic";
+import {
+  ReactNativeWebViewProvider,
+  useReactNativeWebView,
+} from "@/components/shared/providers/WebViewProvider";
 
 const NavBar = dynamic(() => import("@/components/shared/NavBar"), {
   ssr: false,
@@ -38,7 +42,9 @@ export const NextProvider = ({ children }: Props) => {
     <GoogleOAuthProvider clientId="819938529870-7ng56emjnvtfds459lrb7h1a9g04r4q5.apps.googleusercontent.com">
       <QueryClientProvider client={queryClient}>
         <RecoilRoot>
-          <AuthProvider>{children}</AuthProvider>
+          <ReactNativeWebViewProvider>
+            <AuthProvider>{children}</AuthProvider>
+          </ReactNativeWebViewProvider>
           <ToastContainer
             position="top-center"
             hideProgressBar
@@ -73,6 +79,7 @@ const NextLayout = ({ children }: Props) => {
   const router = useRouter();
   useScrollToTop();
   const { isAuthenticated } = useAuth();
+  const { isReactNativeWebView } = useReactNativeWebView();
   const pathname = usePathname();
 
   useEffect(() => {
@@ -91,7 +98,8 @@ const NextLayout = ({ children }: Props) => {
           "max-w-[430px] mx-auto my-0 min-h-dvh",
           isPathIncluded(pathname, DARK_BACKGROUND_PATHS)
             ? "bg-grayscale-50"
-            : "bg-base-white"
+            : "bg-base-white",
+          isReactNativeWebView ? "pt-safe-top" : ""
         )}
       >
         {children}

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -24,10 +24,7 @@ import { useRouter } from "next/navigation";
 import useMaze from "@/hooks/useMaze";
 import useScrollToTop from "@/hooks/useScrollToTop";
 import dynamic from "next/dynamic";
-import {
-  ReactNativeWebViewProvider,
-  useReactNativeWebView,
-} from "@/components/shared/providers/WebViewProvider";
+import { ReactNativeWebViewProvider } from "@/components/shared/providers/ReactNativeWebViewProvider";
 
 const NavBar = dynamic(() => import("@/components/shared/NavBar"), {
   ssr: false,
@@ -79,7 +76,6 @@ const NextLayout = ({ children }: Props) => {
   const router = useRouter();
   useScrollToTop();
   const { isAuthenticated } = useAuth();
-  const { isReactNativeWebView } = useReactNativeWebView();
   const pathname = usePathname();
 
   useEffect(() => {
@@ -98,8 +94,7 @@ const NextLayout = ({ children }: Props) => {
           "max-w-[430px] mx-auto my-0 min-h-dvh",
           isPathIncluded(pathname, DARK_BACKGROUND_PATHS)
             ? "bg-grayscale-50"
-            : "bg-base-white",
-          isReactNativeWebView ? "pt-safe-top" : ""
+            : "bg-base-white"
         )}
       >
         {children}

--- a/src/components/cards/ChooseFrame.tsx
+++ b/src/components/cards/ChooseFrame.tsx
@@ -2,14 +2,20 @@ import { cardFrameAtom } from "@/atoms/card";
 import SelectFrameSwiper from "@/components/cards/SelectFrameSwiper";
 import Flex from "@/components/shared/Flex";
 import Spacing from "@/components/shared/Spacing";
+import clsx from "clsx";
 import { useRecoilValue } from "recoil";
+import { useReactNativeWebView } from "../shared/providers/ReactNativeWebViewProvider";
 
 export default function ChooseFrame({ onNext }: { onNext: () => void }) {
   const selectedFrame = useRecoilValue(cardFrameAtom);
+  const { isReactNativeWebView } = useReactNativeWebView();
 
   return (
     <Flex
-      className="extended-container bg-base-white h-dvh pb-14 overflow-y-scroll"
+      className={clsx(
+        "extended-container bg-base-white h-dvh pb-14 overflow-y-scroll",
+        isReactNativeWebView ? "pt-safe-top" : ""
+      )}
       justify="space-between"
       direction="column"
     >
@@ -26,7 +32,10 @@ export default function ChooseFrame({ onNext }: { onNext: () => void }) {
       <div className={styles.buttonWrapper}>
         <button
           disabled={selectedFrame == null}
-          className={styles.button}
+          className={clsx(
+            styles.button,
+            isReactNativeWebView ? "mb-safe-bottom" : ""
+          )}
           onClick={() => {
             onNext();
           }}

--- a/src/components/cards/ChoosingGatheringToDecorate.tsx
+++ b/src/components/cards/ChoosingGatheringToDecorate.tsx
@@ -10,6 +10,7 @@ import { Feed } from "@/models/feed";
 import { useRouter } from "next/navigation";
 import clsx from "clsx";
 import { NoFeedToMakeCard } from "../feeds/NoFeed";
+import { useReactNativeWebView } from "../shared/providers/ReactNativeWebViewProvider";
 
 export default function ChoosingGatheringToDecorate({
   onNext,
@@ -20,6 +21,7 @@ export default function ChoosingGatheringToDecorate({
     Partial<Feed> & { name: string; imageUrl: string; date: string }
   >(cardSelectedFeedAtom);
   const router = useRouter();
+  const { isReactNativeWebView } = useReactNativeWebView();
 
   const { data = [] } = useFeedMine({
     order: "DESC",
@@ -50,7 +52,14 @@ export default function ChoosingGatheringToDecorate({
     <Flex
       direction="column"
       justify="space-between"
-      className="extended-container bg-base-white h-dvh pt-12 pb-14 overflow-y-scroll no-scrollbar"
+      className={clsx(
+        "extended-container bg-base-white h-dvh pt-12 pb-14 overflow-y-scroll no-scrollbar"
+      )}
+      style={
+        isReactNativeWebView
+          ? { paddingTop: `calc(env(safe-area-inset-top) + 2rem)` }
+          : {}
+      }
     >
       <Flex direction="column">
         <div className="px-6">
@@ -91,7 +100,8 @@ export default function ChoosingGatheringToDecorate({
           <button
             className={clsx(
               styles.button,
-              selectedFeed.id === "" && "!bg-grayscale-200"
+              selectedFeed.id === "" && "!bg-grayscale-200",
+              isReactNativeWebView ? "mb-safe-bottom" : ""
             )}
             disabled={selectedFeed.id === ""}
             onClick={() => {

--- a/src/components/cards/DecorateWithStickers.tsx
+++ b/src/components/cards/DecorateWithStickers.tsx
@@ -17,6 +17,7 @@ import { format } from "date-fns";
 import FloatingButton from "../shared/Button/FloatingButton";
 import BottomButton from "../shared/Button/BottomButton";
 import PhotoSaveBottomSheet from "../shared/BottomDrawer/PhotoSaveBottomSheet";
+import { useReactNativeWebView } from "../shared/providers/ReactNativeWebViewProvider";
 
 export default function DecorateWithStickers() {
   const [decoBottomSheetState, setDecoBottomSheetState] = useRecoilState(
@@ -34,6 +35,7 @@ export default function DecorateWithStickers() {
   const fabricCanvasRef = useRef<fabric.Canvas | null>(null);
   const canvasElementRef = useRef<HTMLCanvasElement | null>(null);
   const ref = useRef<HTMLDivElement>(null);
+  const { isReactNativeWebView } = useReactNativeWebView();
 
   const frames = [
     "https://cdn.lighty.today/frame1.jpeg",
@@ -159,7 +161,10 @@ export default function DecorateWithStickers() {
   return (
     <Flex
       direction="column"
-      className="extended-container !min-h-dvh h-full pb-[60px]"
+      className={clsx(
+        "extended-container !min-h-dvh h-full pb-[60px]",
+        isReactNativeWebView ? "pt-safe-top" : ""
+      )}
     >
       {deco === false ? (
         <Flex
@@ -226,11 +231,13 @@ export default function DecorateWithStickers() {
               </div>
             </Flex>
           </div>
-          <BottomButton
-            disabled={selectedFrame == null}
-            onClick={handleCaptureImage}
-            label="꾸미기 시작"
-          />
+          <div className={isReactNativeWebView ? "mb-safe-bottom" : ""}>
+            <BottomButton
+              disabled={selectedFrame == null}
+              onClick={handleCaptureImage}
+              label="꾸미기 시작"
+            />
+          </div>
         </Flex>
       ) : (
         <>
@@ -263,7 +270,12 @@ export default function DecorateWithStickers() {
           />
         </div>
         {deco && (
-          <div className="absolute bottom-[60px] left-0 right-0">
+          <div
+            className={clsx(
+              "absolute bottom-[60px] left-0 right-0",
+              isReactNativeWebView ? "mb-safe-bottom" : ""
+            )}
+          >
             <FloatingButton tooltip />
             <BottomButton
               label={"이미지 저장"}

--- a/src/components/feeds/ChoosingGatheringToRecord.tsx
+++ b/src/components/feeds/ChoosingGatheringToRecord.tsx
@@ -7,6 +7,7 @@ import FixedBottomButton from "../shared/Button/FixedBottomButton";
 import BigClickableGatheringSwiper from "./BigClickableGatheringSwiper";
 import useGatheringNoFeeds from "../gathering/hooks/useGatheringNoFeed";
 import NoGatheringToRecord from "../gathering/NoGatheringToRecord";
+import { useReactNativeWebView } from "../shared/providers/ReactNativeWebViewProvider";
 
 export default function ChoosingGatheringToRecord({
   onNext,
@@ -21,6 +22,7 @@ export default function ChoosingGatheringToRecord({
   const handleImageClick = (gatheringId: string) => {
     setSelectedGatheringId(gatheringId);
   };
+  const { isReactNativeWebView } = useReactNativeWebView();
 
   return (
     <>
@@ -52,6 +54,7 @@ export default function ChoosingGatheringToRecord({
             selectedGatheringId={selectedGatheringId}
           />
           <FixedBottomButton
+            className={isReactNativeWebView ? "mb-safe-bottom" : ""}
             bgColor="#f4f4f4"
             disabled={selectedGatheringId === null}
             label={"기록 시작하기"}

--- a/src/components/feeds/ChoosingKindOfMemory.tsx
+++ b/src/components/feeds/ChoosingKindOfMemory.tsx
@@ -4,6 +4,7 @@ import Spacing from "../shared/Spacing";
 import clsx from "clsx";
 import { Dispatch, SetStateAction } from "react";
 import FixedBottomButton from "../shared/Button/FixedBottomButton";
+import { useReactNativeWebView } from "../shared/providers/ReactNativeWebViewProvider";
 
 export default function ChoosingKindOfMemory({
   add,
@@ -14,6 +15,7 @@ export default function ChoosingKindOfMemory({
   setAdd: Dispatch<SetStateAction<number>>;
   setStep: Dispatch<SetStateAction<number>>;
 }) {
+  const { isReactNativeWebView } = useReactNativeWebView();
   return (
     <>
       <Flex direction="column" className="pt-5 px-6 gap-4 text-T2">
@@ -42,6 +44,7 @@ export default function ChoosingKindOfMemory({
         bgColor="#f4f4f4"
         disabled={add < 1}
         label={"다음"}
+        className={isReactNativeWebView ? "mb-safe-bottom" : ""}
         onClick={() => {
           setStep((prev) => prev + add);
         }}

--- a/src/components/feeds/FeedForm.tsx
+++ b/src/components/feeds/FeedForm.tsx
@@ -7,6 +7,7 @@ import FixedBottomButton from "../shared/Button/FixedBottomButton";
 import * as lighty from "lighty-type";
 import { GatheringDetailResponse } from "@/models/gathering";
 import { Feed } from "@/models/feed";
+import { useReactNativeWebView } from "../shared/providers/ReactNativeWebViewProvider";
 
 interface FeedFormProps<T> {
   edit?: () => void;
@@ -38,6 +39,7 @@ export default function FeedForm<
       setFeedInfo((prev) => ({ ...prev, content: e.target.value }));
     }
   };
+  const { isReactNativeWebView } = useReactNativeWebView();
   console.log(selectedGathering, "selectedGatherings");
   return (
     <>
@@ -93,6 +95,7 @@ export default function FeedForm<
         />
       ) : (
         <FixedBottomButton
+          className={isReactNativeWebView ? "mb-safe-bottom" : ""}
           label={"기록 완료"}
           disabled={filesToUpload.length == 0 || !feedInfo?.content}
           onClick={() => {

--- a/src/components/friends/SelectFriendsContainer.tsx
+++ b/src/components/friends/SelectFriendsContainer.tsx
@@ -12,6 +12,7 @@ import Modal from "../shared/Modal/Modal";
 import { friendsToShareAtom } from "@/atoms/record";
 import { useAuth } from "../shared/providers/AuthProvider";
 import clsx from "clsx";
+import { useReactNativeWebView } from "../shared/providers/ReactNativeWebViewProvider";
 
 export default function SelectFriendsContainer({
   type = "default",
@@ -38,6 +39,7 @@ export default function SelectFriendsContainer({
   const setFriendsToShare = useSetRecoilState<lighty.User[] | []>(
     friendsToShareAtom
   );
+  const { isReactNativeWebView } = useReactNativeWebView();
 
   const { data: friends } = useFriends({ userId: userInfo?.accountId || "" });
 
@@ -137,6 +139,7 @@ export default function SelectFriendsContainer({
         <Spacing size={50} />
       </ul>
       <FixedBottomButton
+        className={isReactNativeWebView ? "mb-safe-bottom" : ""}
         bgColor="bg-grayscale-50"
         label={getLabel()}
         disabled={type == "record" ? false : clickedItems.length < 1}

--- a/src/components/notice/NoticeContainer.tsx
+++ b/src/components/notice/NoticeContainer.tsx
@@ -5,12 +5,15 @@ import ReportNoticeItem from "./ReportNoticeItem";
 import { useInfiniteScrollByRef } from "@/hooks/useInfiniteScroll";
 import { useRef } from "react";
 import NoticeSkeleton from "../shared/Skeleton/NoticeSkeleton";
+import clsx from "clsx";
+import { useReactNativeWebView } from "../shared/providers/ReactNativeWebViewProvider";
 
 export default function NoticeContainer() {
   const { data: notifications = [], isFetching, loadMore } = useNotification();
   const containerRef = useRef<HTMLDivElement>(null);
   const today: Notification[] = [];
   const passed: Notification[] = [];
+  const { isReactNativeWebView } = useReactNativeWebView();
 
   notifications.forEach((notification) => {
     const isToday =
@@ -31,7 +34,10 @@ export default function NoticeContainer() {
   return (
     <div
       ref={containerRef}
-      className="h-dvh overflow-y-scroll no-scrollbar gap-10 pt-[60px] px-5 pb-10"
+      className={clsx(
+        "h-dvh overflow-y-scroll no-scrollbar gap-10 pt-[60px] px-5 pb-10",
+        isReactNativeWebView ? "pt-safe-top" : ""
+      )}
     >
       <div className="flex flex-col gap-5">
         {today.length > 0 && (

--- a/src/components/shared/providers/ReactNativeWebViewProvider.tsx
+++ b/src/components/shared/providers/ReactNativeWebViewProvider.tsx
@@ -1,0 +1,36 @@
+"use client";
+import React, { createContext, useContext, useState, useEffect } from "react";
+
+interface ReactNativeWebViewContextType {
+  isReactNativeWebView: boolean;
+}
+
+const ReactNativeWebViewContext = createContext<
+  ReactNativeWebViewContextType | undefined
+>(undefined);
+
+export const useReactNativeWebView = () => {
+  const context = useContext(ReactNativeWebViewContext);
+  if (!context) {
+    throw new Error("ReactNativeWebView context 없음.");
+  }
+  return context;
+};
+
+export const ReactNativeWebViewProvider: React.FC<{
+  children: React.ReactNode;
+}> = ({ children }) => {
+  const [isReactNativeWebView, setIsReactNativeWebView] = useState(false);
+
+  useEffect(() => {
+    if (typeof window !== "undefined" && window.ReactNativeWebView) {
+      setIsReactNativeWebView(true);
+    }
+  }, []);
+
+  return (
+    <ReactNativeWebViewContext.Provider value={{ isReactNativeWebView }}>
+      {children}
+    </ReactNativeWebViewContext.Provider>
+  );
+};


### PR DESCRIPTION
## 작업 내용
- 웹뷰인지 아닌지 확인할 때 쓰려고 context 하나 만들었어요. 7556849acc9480c1f7ed9d4d48fedfbfaafda58b
  - 공통 layout에서 상단 패딩 넣어보려고 했다가 기존 속성 많이 건드려야할 거 같아서 빼고 화면 별로 넣는 중이에요.
- 바텀 네비에 있는 카드 꾸미기 페이지 관련 모든 화면에 safe area inset 추가.
- 피드 작성 화면 모든 버튼에 safe area inset 추가.
- 알림 화면 safe area instet 추가.
- 초대장 화면 safe area instet 추가.
## 특이 사항
- 충돌 날까봐 최소 단위로 pr 넣을 생각입니당.
- 꾸미기 시작 버튼 밑에 여백이 많아요. 일단 다른 화면이랑 동일하게 작업은 했어요
<img width="428" alt="스크린샷 2025-03-12 오전 12 09 04" src="https://github.com/user-attachments/assets/562c6c71-831a-41ba-860b-ec4037dd31b1" />