### PR TITLE
애플 탈퇴 구현

### DIFF
--- a/src/components/my/SettingsMenuItem.tsx
+++ b/src/components/my/SettingsMenuItem.tsx
@@ -7,6 +7,8 @@ import { deleteUser } from "@/remote/users";
 import { lightyToast } from "@/utils/toast";
 import { useRouter } from "next/navigation";
 import DotSpinnerSmall from "../shared/Spinner/DotSpinnerSmall";
+import useUserDetail from "@/components/users/hooks/useUserDetail";
+import { appleLoginMobile } from "@/webview/actions";
 
 export default function SettingsMenuItem({
   list,
@@ -18,6 +20,7 @@ export default function SettingsMenuItem({
   user: string[];
 }) {
   const router = useRouter();
+  const { data: userInfo } = useUserDetail();
   const [loading, setLoading] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const handleClick = () => {
@@ -27,11 +30,15 @@ export default function SettingsMenuItem({
   };
 
   const accountDelete = async () => {
+    if (userInfo?.provider === "APPLE") {
+      appleLoginMobile();
+      return;
+    }
     setLoading(true);
+
     try {
       await deleteUser();
       localStorage.clear();
-
       document.cookie =
         "refresh_token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
 
@@ -69,7 +76,7 @@ export default function SettingsMenuItem({
         <Modal
           action={accountDelete}
           title="탈퇴하시겠어요?"
-          content="탈퇴 시 모든 활동 내용이 삭제되며 해당 정보는 복구할 수 없어요."
+          content="30일 이내에 로그인 시 계정이 복구되며, 이후엔 불가해요."
           left="닫기"
           right="탈퇴"
           onClose={() => setIsModalOpen(false)}

--- a/src/remote/users.ts
+++ b/src/remote/users.ts
@@ -1,6 +1,7 @@
 import * as lighty from "lighty-type";
 import { API_CONFIG, fetchWithAuth } from "./shared";
 import { lightyToast } from "@/utils/toast";
+import { logger } from "@/utils/logger";
 
 /** 유저 검색 */
 export async function getSearchUsers({
@@ -94,12 +95,16 @@ export async function patchNotificationToken(
   }
 }
 
-export async function deleteUser() {
+// TODO body 타입은 dto 업데이트 후 수정해야해요.
+export async function deleteUser(body?: { authorizationCode?: string }) {
+  logger.info("탈퇴 요청 시작");
   const baseUrl = API_CONFIG.getBaseUrl();
   try {
     const targetUrl = `${baseUrl}/users`;
     const response = await fetchWithAuth(targetUrl, {
       method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: body?.authorizationCode ? JSON.stringify(body) : undefined,
     });
     if (response.status === 204) {
       return "탈퇴 성공";
@@ -107,5 +112,6 @@ export async function deleteUser() {
   } catch (error) {
     console.log(error);
     lightyToast.error("탈퇴 실패");
+    throw error;
   }
 }


### PR DESCRIPTION
## 작업 내용
- 애플 회원 탈퇴 프로세스
  1. 탈퇴 버튼 클릭
  2. 애플 로그인 요청
  3. 로그인 성공 시 authorizationCode를 받아와서 deleteUser 요청
  4. 탈퇴 성공 시 "/"로 이동
- 탈퇴 시 애플만 authorizationCode를 body로 가져야해서 deleteUser 함수에 옵셔널로 body 추가함.
- 기존 deleteUser 함수는 예외 발생 시 throw error를 안 하고 있어서 호출하는 쪽에서 deleteUser가 실패해서 아래 코드들이 모두 실행됐었음.
  -> throw error 추가
- 탈퇴 이후 localstorage clear 및 이동 코드는 기존 탈퇴 코드에서 복붙했어요.
- 탈퇴 모달 문구 변경.
 