### PR TITLE
스티커 삭제 기능 추가 및 UI 개선

### DIFF
--- a/src/app/card/page.tsx
+++ b/src/app/card/page.tsx
@@ -5,12 +5,20 @@ import { useRouter } from "next/navigation";
 import dynamic from "next/dynamic";
 import FramePageSkeleton from "@/components/shared/Skeleton/FramePageSkeleton";
 import HeaderWithBtn from "@/components/shared/Header/HeaderWithBtn";
-import DecorateWithStickers from "@/components/cards/DecorateWithStickers";
+import DotSpinner from "@/components/shared/Spinner/DotSpinner";
 
 const ChooseFrame = dynamic(() => import("@/components/cards/ChooseFrame"), {
   ssr: false,
   loading: () => <FramePageSkeleton />,
 });
+
+const DecorateWithStickers = dynamic(
+  () => import("@/components/cards/DecorateWithStickers"),
+  {
+    ssr: false,
+    loading: () => <DotSpinner />,
+  }
+);
 
 export default function Page() {
   const [step, setStep] = useState<number>(1);

--- a/src/components/shared/Button/FloatingButton.tsx
+++ b/src/components/shared/Button/FloatingButton.tsx
@@ -12,6 +12,7 @@ import { decoBottomSheetStateAtom } from "@/atoms/card";
 
 interface FloatingButtonProps {
   tooltip?: boolean;
+  onClick?: () => void;
 }
 
 type PathConfig = {
@@ -38,7 +39,10 @@ const PATH_CONFIGS: PathConfig[] = [
   },
 ];
 
-const FloatingButton: FC<FloatingButtonProps> = ({ tooltip = false }) => {
+const FloatingButton: FC<FloatingButtonProps> = ({
+  tooltip = false,
+  onClick,
+}) => {
   const pathname = usePathname();
   const getPathConfig = () => {
     return (
@@ -51,6 +55,7 @@ const FloatingButton: FC<FloatingButtonProps> = ({ tooltip = false }) => {
 
   const handleClick = () => {
     setModalOpen(true);
+    onClick?.();
   };
 
   return (


### PR DESCRIPTION
## 변경 사항

### 스티커 삭제 기능 추가

- 스티커를 클릭했을 때 우측 상단에 삭제 버튼(X 아이콘)이 나타나도록 구현했습니다.
- 삭제 버튼을 클릭하면 해당 스티커가 캔버스에서 제거됩니다.
- fabric.js의 `Control` 기능을 활용하여 커스텀 컨트롤을 추가했습니다.


### 삭제 아이콘 UI 개선

- 삭제 아이콘의 크기를 24px에서 18px로 줄였습니다.
- X 의 크기를 줄이고(size/4에서 size/5로) 선 두께를 1.5px로 줄였습니다.


### 기타 개선 사항

- 이미지 저장 시 선택된 스티커의 컨트롤이 보이지 않도록 `discardActiveObject()` 메서드 추가
- 스티커 선택 시 이벤트 리스너를 추가해 컨트롤의 가시성 관리