### PR TITLE
Fix: Feed 페이지에서 탭과 Swiper 슬라이드 불일치 문제 해결

### DIFF
--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -56,13 +56,7 @@ export default function FeedPage() {
     userInfo,
   } = useFeed();
 
-  const {
-    selectedTab,
-    handleTabClick,
-    handleSlideChange,
-    swiperRef,
-    setSelectedTab,
-  } = useTabs();
+  const { selectedTab, handleTabClick, swiperRef, setSelectedTab } = useTabs();
 
   const containerRef = useRef<HTMLDivElement>(null);
   const containerRef_m = useRef<HTMLDivElement>(null);
@@ -115,8 +109,11 @@ export default function FeedPage() {
   );
 
   useEffect(() => {
-    if (swiperRef.current) {
-      swiperRef.current.slideTo(Number(selectedTab) - 1);
+    if (swiperRef.current && typeof swiperRef.current.slideTo === "function") {
+      const targetIndex = Number(selectedTab) - 1;
+      if (swiperRef.current.activeIndex !== targetIndex) {
+        swiperRef.current.slideTo(targetIndex);
+      }
     }
   }, [selectedTab]);
 
@@ -136,7 +133,10 @@ export default function FeedPage() {
             swiperRef.current = swiper;
           }}
           onSlideChange={(swiper) => {
-            handleSlideChange(swiper.activeIndex);
+            const index = swiper.activeIndex;
+            if (selectedTab !== String(index + 1)) {
+              setSelectedTab(String(index + 1) as "1" | "2");
+            }
           }}
           slidesPerView={1}
           spaceBetween={2}

--- a/src/components/cards/DecorateWithStickers.tsx
+++ b/src/components/cards/DecorateWithStickers.tsx
@@ -114,7 +114,7 @@ export default function DecorateWithStickers() {
     ctx.rotate(fabric.util.degreesToRadians(fabricObject.angle || 0));
 
     // Draw circle background
-    ctx.fillStyle = "#393939";
+    ctx.fillStyle = "#979797";
     ctx.beginPath();
     ctx.arc(0, 0, size / 2, 0, 2 * Math.PI);
     ctx.fill();
@@ -142,8 +142,8 @@ export default function DecorateWithStickers() {
         });
 
         stickerObj.set({
-          scaleX: 0.24,
-          scaleY: 0.24,
+          scaleX: 0.22,
+          scaleY: 0.22,
           cornerSize: 9,
           cornerColor: "white",
           cornerStrokeColor: "#AEAEAE",


### PR DESCRIPTION
🔧 Problem

- Feed 페이지에서 활성화된 탭과 Swiper의 활성화된 슬라이드가 간헐적으로 불일치하는 문제가 발생

- Swiper의 슬라이드 전환 애니메이션이 완료되기 전에 상태 업데이트가 이루어지면서 이벤트 전파 충돌이 원인으로 추정


✅ Solution

- slideTo 함수 사용으로 상태 변경 시 중복 호출을 방지

- Swiper 초기화 완료 후에만 slideTo 함수를 호출하여 초기 렌더링 문제를 해결


